### PR TITLE
fix: exclude rejected complaints from pending constituency assignment

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1634,7 +1634,8 @@ router.get('/stats', apiLimiter, async (req, res) => {
 router.get('/assignments/pending', apiLimiter, async (req, res) => {
   try {
     const pendingPotholes = await Pothole.find({
-      constituencyStatus: 'pending_manual'
+      constituencyStatus: 'pending_manual',
+      approvalStatus: { $ne: 'rejected' }
     })
     .select('reportId location createdAt state constituency parliamentaryConstituency')
     .sort({ createdAt: -1 })

--- a/backend/services/constituencyAssignmentService.js
+++ b/backend/services/constituencyAssignmentService.js
@@ -185,7 +185,8 @@ class ConstituencyAssignmentService {
     try {
       const unassignedPotholes = await Pothole.find({
         constituencyStatus: 'pending_manual',
-        state: 'Pending Assignment'
+        state: 'Pending Assignment',
+        approvalStatus: { $ne: 'rejected' }
       }).select('_id location');
 
       console.log(`Processing ${unassignedPotholes.length} unassigned potholes`);
@@ -208,6 +209,11 @@ class ConstituencyAssignmentService {
   async getAssignmentStats() {
     try {
       const stats = await Pothole.aggregate([
+        {
+          $match: {
+            approvalStatus: { $ne: 'rejected' }
+          }
+        },
         {
           $group: {
             _id: '$constituencyStatus',


### PR DESCRIPTION
- Updated admin route /api/admin/assignments/pending to exclude rejected complaints
- Updated constituencyAssignmentService.getAssignmentStats() to exclude rejected complaints
- Updated constituencyAssignmentService.processUnassignedPotholes() to skip rejected complaints
- Reduces pending assignment count from 43 to 26 (removes 17 rejected complaints)
- Ensures only approved and pending complaints are shown in admin dashboard